### PR TITLE
テキスト中からurlと謎文字を削除（remove_urljとremove_strange)ブランチ再設定

### DIFF
--- a/src/preprocessing/scripts/filter_data.py
+++ b/src/preprocessing/scripts/filter_data.py
@@ -46,6 +46,8 @@ from filters import (
     has_sentence_with_min_length,
     has_documents_with_min_length,
     mask_phone_and_email,
+    remove_urlj,
+    remove_strange,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,6 +135,8 @@ def reformat_and_filter_dataset(
         filter_fns.append(has_documents_with_min_length())
         filter_fns.append(has_valid_alphanum_fraction())
         map_fns.append(mask_phone_and_email())
+        filter_fns.append(remove_urlj())
+        filter_fns.append(remove_strange())
     elif dataset_name == "cc":
         reformat_fn = reformat_data("text")
         # write me

--- a/src/preprocessing/scripts/filter_data.py
+++ b/src/preprocessing/scripts/filter_data.py
@@ -135,8 +135,8 @@ def reformat_and_filter_dataset(
         filter_fns.append(has_documents_with_min_length())
         filter_fns.append(has_valid_alphanum_fraction())
         map_fns.append(mask_phone_and_email())
-        filter_fns.append(remove_urlj())
-        filter_fns.append(remove_strange())
+        map_fns.append(remove_urlj())
+        map_fns.append(remove_strange())
     elif dataset_name == "cc":
         reformat_fn = reformat_data("text")
         # write me

--- a/src/preprocessing/scripts/filters.py
+++ b/src/preprocessing/scripts/filters.py
@@ -610,7 +610,7 @@ def mask_phone_and_email() -> Callable[..., dict[str, Any]]:
 # url表記を削除（日本語表記含む）
 def remove_urlj() -> Callable[..., dict[str, Any]]:
     def urlj_sub(example: dict[str, Any]) -> dict[str, Any]:
-        urlj_pat = r"(https?://|www\.|/www\.|ftp:|url)[\p{L}\p{M}\w!\?/\+\-_~=;\.,\*&@#\$%\(\)'\[\]]+"
+        urlj_pat = r"(https?://|www\.|//|/www\.|ftp:|file:|url)[\p{L}\p{M}\w%\?\+\-\.\*\$\(\)\[\]/!_~=:;,&@#']+"
         compiled_pattern = regex.compile(urlj_pat)
         example["text"] = compiled_pattern.sub("", example["text"])
         return example
@@ -621,11 +621,7 @@ def remove_urlj() -> Callable[..., dict[str, Any]]:
 # 通常の日本語使用者に理解できない記号を削除
 def remove_strange() -> Callable[..., dict[str, Any]]:
     def strange_sub(example: dict[str, Any]) -> dict[str, Any]:
-        strange_pat = (
-            r"[^\p{Script=Latin}\p{Number}\p{Punctuation}\p{Symbol}"
-            r"\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]"
-        )
-
+        strange_pat = r"[^\p{N}\p{P}\p{S}\p{Latin}\p{Hiragana}\p{Katakana}\p{Han}\nー]"
         remove_strange = regex.compile(strange_pat)
         example["text"] = remove_strange.sub("", example["text"])
         return example

--- a/src/preprocessing/scripts/filters.py
+++ b/src/preprocessing/scripts/filters.py
@@ -621,7 +621,7 @@ def remove_urlj() -> Callable[..., dict[str, Any]]:
 # 通常の日本語使用者に理解できない記号を削除
 def remove_strange() -> Callable[..., dict[str, Any]]:
     def strange_sub(example: dict[str, Any]) -> dict[str, Any]:
-        strange_pat = r"[^\p{N}\p{P}\p{S}\p{Latin}\p{Hiragana}\p{Katakana}\p{Han}\nー]"
+        strange_pat = r"[^\p{N}\p{P}\p{S}\p{Latin}\p{Hiragana}\p{Katakana}\p{Han}\nー ]"
         remove_strange = regex.compile(strange_pat)
         example["text"] = remove_strange.sub("", example["text"])
         return example

--- a/src/preprocessing/scripts/filters.py
+++ b/src/preprocessing/scripts/filters.py
@@ -624,6 +624,7 @@ def remove_strange() -> Callable[..., dict[str, Any]]:
         strange_pat = r"[^\p{N}\p{P}\p{S}\p{Latin}\p{Hiragana}\p{Katakana}\p{Han}\nー ]"
         remove_strange = regex.compile(strange_pat)
         example["text"] = remove_strange.sub("", example["text"])
+        example["text"] = example["text"].replace("�", "")
         return example
 
     return strange_sub


### PR DESCRIPTION
- remove_urlj
    - http:などのurlを削除、ftp: や日本語を含む場合も対応。
    - 周囲の（）等は残ります。

- remove_strange
    - 謎文字を削除（通常の日本語話者が意味を読み取れるものは残している）